### PR TITLE
项目重构：增加配置管理文档、LLM工厂文档

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,22 @@
+"""
+初始化模块
+"""
+
+from .translation_agent import TranslationAgent
+from .markdown_parser import MarkdownParser, Metadata
+from .translator import SmartTranslator
+from .text_chunker import MarkdownChunker, TextChunk
+from .summary_generator import SummaryGenerator
+
+__version__ = "1.0.0"
+__author__ = "Translation Agent Developer"
+
+__all__ = [
+    "TranslationAgent",
+    "MarkdownParser",
+    "Metadata",
+    "SmartTranslator",
+    "MarkdownChunker",
+    "TextChunk",
+    "SummaryGenerator"
+]

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -1,0 +1,157 @@
+"""
+配置管理器 - 支持配置文件和直接参数两种方式
+"""
+
+import os
+import configparser
+from typing import Dict, Optional
+from pathlib import Path
+
+
+class ConfigManager:
+    
+    def __init__(self, config_file: str = None):
+        """
+        初始化配置管理
+        """
+        if config_file is None:
+
+            current_dir = Path(__file__).parent.parent
+            config_file = current_dir / "config.ini"
+
+            if not config_file.exists():
+                example_config = current_dir / "config.ini.example"
+                if example_config.exists():
+                    print(f"配置文件不存在，请复制 {example_config} 为 {config_file} 并填入您的API密钥")
+                config_file = None
+        
+        self.config_file = config_file
+        self.config = configparser.ConfigParser()
+        
+        if config_file and os.path.exists(config_file):
+            self.config.read(config_file, encoding='utf-8')
+            print(f"已加载配置文件: {config_file}")
+        else:
+            print("未找到配置文件，将使用参数传递模式")
+    
+    def get_openai_config(self, api_key: str = None, base_url: str = None) -> Dict[str, Optional[str]]:
+
+        config = {
+            'api_key': api_key,
+            'base_url': base_url
+        }
+
+        if not api_key and self.config.has_section('openai'):
+            config['api_key'] = self.config.get('openai', 'api_key', fallback=None)
+            if config['api_key'] == 'your_openai_api_key_here':
+                config['api_key'] = None
+        
+        if not base_url and self.config.has_section('openai'):
+            config['base_url'] = self.config.get('openai', 'base_url', fallback='https://api.openai.com/v1')
+
+        if not config['api_key']:
+            config['api_key'] = os.getenv('OPENAI_API_KEY')
+        if not config['base_url']:
+            config['base_url'] = os.getenv('OPENAI_BASE_URL', 'https://api.openai.com/v1')
+        
+        return config
+    
+    def get_qwen_config(self, api_key: str = None) -> Dict[str, Optional[str]]:
+        """
+        Qwen配置
+        """
+        config = {
+            'api_key': api_key
+        }
+
+        if not api_key and self.config.has_section('qwen'):
+            config['api_key'] = self.config.get('qwen', 'api_key', fallback=None)
+            if config['api_key'] == 'your_dashscope_api_key_here':
+                config['api_key'] = None
+
+        if not config['api_key']:
+            config['api_key'] = os.getenv('DASHSCOPE_API_KEY')
+        
+        return config
+    
+    def get_default_config(self) -> Dict[str, str]:
+        """
+        获取默认配置
+        """
+        defaults = {
+            'model_name': 'gpt-3.5-turbo',
+            'provider': 'auto',
+            'translator_id': 'FILL_YOUR_GITHUB_ID_HERE',
+            'max_tokens': '800'
+        }
+        
+        if self.config.has_section('default'):
+            for key in defaults:
+                value = self.config.get('default', key, fallback=defaults[key])
+                defaults[key] = value
+
+        defaults['model_name'] = os.getenv('MODEL_NAME', defaults['model_name'])
+        defaults['provider'] = os.getenv('MODEL_PROVIDER', defaults['provider'])
+        
+        return defaults
+    
+    def validate_config(self, provider: str, **kwargs) -> bool:
+        """
+        验证配置是否完整
+        """
+        if provider.lower() == 'openai':
+            openai_config = self.get_openai_config(
+                api_key=kwargs.get('openai_api_key'),
+                base_url=kwargs.get('openai_base_url')
+            )
+            return bool(openai_config['api_key'])
+        
+        elif provider.lower() == 'qwen':
+            qwen_config = self.get_qwen_config(
+                api_key=kwargs.get('qwen_api_key')
+            )
+            return bool(qwen_config['api_key'])
+        
+        elif provider.lower() == 'auto':
+            openai_valid = bool(self.get_openai_config(
+                api_key=kwargs.get('openai_api_key')
+            )['api_key'])
+            qwen_valid = bool(self.get_qwen_config(
+                api_key=kwargs.get('qwen_api_key')
+            )['api_key'])
+            return openai_valid or qwen_valid
+        
+        return False
+    
+    def create_sample_config(self, config_path: str = None):
+
+        if config_path is None:
+            config_path = Path(__file__).parent.parent / "config.ini"
+        
+        sample_config = """# 智能翻译代理配置文件
+# 请根据需要配置相应的API密钥
+
+[openai]
+# OpenAI API配置
+api_key = your_openai_api_key_here
+base_url = https://api.openai.com/v1
+
+[qwen]
+# 阿里云Qwen API配置
+api_key = your_dashscope_api_key_here
+
+[default]
+# 默认配置
+model_name = gpt-3.5-turbo
+provider = auto
+translator_id = FILL_YOUR_GITHUB_ID_HERE
+max_tokens = 800
+"""
+        
+        with open(config_path, 'w', encoding='utf-8') as f:
+            f.write(sample_config)
+        
+        print(f"已创建示例配置文件: {config_path}")
+        print("   编辑该文件并填入API密钥")
+
+config_manager = ConfigManager()

--- a/src/llm_factory.py
+++ b/src/llm_factory.py
@@ -1,0 +1,234 @@
+"""
+LLM工厂 - 支持多种模型提供商
+"""
+
+import os
+import json
+from typing import Optional, Any, List, Dict, Union
+from langchain_openai import ChatOpenAI
+from langchain.llms.base import LLM
+from pydantic import Field
+
+from .config_manager import config_manager
+
+
+class QwenChatModel(LLM):
+    """
+    Qwen模型的LangChain兼容包装器 - 使用OpenAI SDK
+    """
+    
+    model: str = Field(default="qwen-plus", description="模型名称")
+    temperature: float = Field(default=0.1, description="生成的随机性")
+    client: Any = Field(default=None, description="OpenAI客户端")
+    
+    class Config:
+        """Pydantic配置"""
+        arbitrary_types_allowed = True
+    
+    def __init__(self, model: str = "qwen-plus", temperature: float = 0.1, api_key: str = None, **kwargs):
+        """
+        初始化Qwen模型
+        
+        Args:
+            model: 模型名称 (qwen-plus, qwen-max, qwen-turbo)
+            temperature: 生成的随机性
+            api_key: API密钥（可选，优先级高于配置文件）
+        """
+        try:
+            from openai import OpenAI
+        except ImportError:
+            raise ImportError("请安装 openai: pip install openai>=1.0.0")
+        
+        # 获取API密钥配置
+        qwen_config = config_manager.get_qwen_config(api_key=api_key)
+        if not qwen_config['api_key']:
+            raise ValueError("请在配置文件config.ini中设置qwen.api_key，或通过参数传递API密钥")
+        
+        # 使用OpenAI SDK创建客户端
+        client = OpenAI(
+            api_key=qwen_config['api_key'],
+            base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        )
+        
+        # 调用父类初始化
+        super().__init__(
+            model=model,
+            temperature=temperature,
+            client=client,
+            **kwargs
+        )
+    
+    def _safe_format_messages(self, messages: Union[str, List, Any]) -> List[Dict[str, str]]:
+
+        if isinstance(messages, str):
+            return [{"role": "user", "content": messages}]
+
+        if hasattr(messages, 'format'):
+            formatted_content = str(messages)
+            return [{"role": "user", "content": formatted_content}]
+
+        if isinstance(messages, list):
+            formatted_messages = []
+            for msg in messages:
+                if hasattr(msg, 'content'):
+                    role = getattr(msg, 'type', 'user')
+                    if role == 'human':
+                        role = 'user'
+                    elif role == 'ai':
+                        role = 'assistant'
+                    elif role == 'system':
+                        role = 'system'
+                
+                    content = msg.content
+                    if isinstance(content, list):
+                        content = ' '.join(str(item) for item in content)
+                    
+                    formatted_messages.append({"role": role, "content": str(content)})
+                elif isinstance(msg, dict):
+                    safe_msg = {}
+                    for k, v in msg.items():
+                        safe_msg[k] = str(v) if not isinstance(v, (str, int, float, bool)) else v
+                    formatted_messages.append(safe_msg)
+                else:
+                    formatted_messages.append({"role": "user", "content": str(msg)})
+            return formatted_messages
+        
+        return [{"role": "user", "content": str(messages)}]
+    
+    @property
+    def _llm_type(self) -> str:
+        """返回LLM类型"""
+        return "qwen"
+    
+    def _call(self, prompt: str, stop: Optional[List[str]] = None, **kwargs) -> str:
+
+        try:
+            # 调用Qwen
+            completion = self.client.chat.completions.create(
+                model=self.model,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=self.temperature,
+                stop=stop,
+                **kwargs
+            )
+            
+            return completion.choices[0].message.content
+                
+        except Exception as e:
+            raise Exception(f"Qwen模型调用出错: {str(e)}")
+    
+    def invoke(self, input, config=None, **kwargs):
+        try:
+            formatted_messages = self._safe_format_messages(input)
+            
+            # 调用Qwen API
+            completion = self.client.chat.completions.create(
+                model=self.model,
+                messages=formatted_messages,
+                temperature=self.temperature,
+                **kwargs
+            )
+            
+            response_text = completion.choices[0].message.content
+            return response_text
+                
+        except Exception as e:
+            raise Exception(f"Qwen模型调用出错: {str(e)}")
+
+
+class QwenResponse:
+    
+    def __init__(self, content: str):
+        self.content = content
+        self.text = content 
+        self.generations = [self] 
+    
+    def __str__(self):
+        return self.content
+    
+    def __repr__(self):
+        return f"QwenResponse(content='{self.content[:50]}...')"
+    
+    @property
+    def generation_info(self):
+        return {}
+    
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return self.content == other
+        elif hasattr(other, 'content'):
+            return self.content == other.content
+        return False
+
+
+class LLMFactory:
+    
+    @staticmethod
+    def get_supported_models() -> Dict[str, List[str]]:
+        """获取支持的模型列表"""
+        return {
+            "openai": [
+                "gpt-4",
+                "gpt-3.5-turbo-16k"
+            ],
+            "qwen": [
+                "qwen-plus",
+                "qwen-max", 
+                "qwen-turbo"
+            ]
+        }
+    
+    @staticmethod
+    def create_llm(model_name: str, 
+                   provider: str = "auto", 
+                   temperature: float = 0.1,
+                   openai_api_key: Optional[str] = None,
+                   qwen_api_key: Optional[str] = None,
+                   **kwargs):
+
+        if provider == "auto":
+            supported_models = LLMFactory.get_supported_models()
+            for provider_name, models in supported_models.items():
+                if model_name in models:
+                    provider = provider_name
+                    break
+            
+            if provider == "auto":
+                raise ValueError(f"无法自动识别模型 {model_name} 的提供商")
+
+        if provider == "openai":
+            return LLMFactory._create_openai_llm(
+                model_name, temperature, openai_api_key, **kwargs
+            )
+        elif provider == "qwen":
+            return LLMFactory._create_qwen_llm(
+                model_name, temperature, qwen_api_key, **kwargs
+            )
+        else:
+            raise ValueError(f"不支持的提供商: {provider}")
+    
+    @staticmethod
+    def _create_openai_llm(model_name: str, temperature: float, api_key: Optional[str] = None, **kwargs):
+
+        openai_config = config_manager.get_openai_config(api_key=api_key)
+        
+        if not openai_config['api_key']:
+            raise ValueError("在配置文件config.ini中设置openai.api_key")
+        
+        return ChatOpenAI(
+            model=model_name,
+            temperature=temperature,
+            openai_api_key=openai_config['api_key'],
+            openai_api_base=openai_config.get('base_url'),
+            **kwargs
+        )
+    
+    @staticmethod  
+    def _create_qwen_llm(model_name: str, temperature: float, api_key: Optional[str] = None, **kwargs):
+        
+        return QwenChatModel(
+            model=model_name,
+            temperature=temperature,
+            api_key=api_key,
+            **kwargs
+        )


### PR DESCRIPTION
# config_manager.py


- `get_openai_config`
获取 OpenAI API 的配置。

-  `get_qwen_config`
获取 QwenAPI 的配置。


- `get_default_config
`获取默认配置项（模型名、provider、ID、最大token）。


- `validate_config
`验证配置是否完整。


- `create_sample_config
`生成config.ini

# LLM_factory

##  QwenChatModel 类

-  `_safe_format_messages`将输入消息格式化为 Qwen API 兼容的格式，支持字符串、列表、对象等多种输入。
-  `_llm_type`返回模型类型（如 "qwen"）。
-  `_call`底层调用 Qwen API，传入 prompt，返回模型生成的文本。
-  `invoke`高级调用接口，支持格式化消息和参数，返回模型响应文本。

##  QwenResponse 类
封装 Qwen 模型的响应结果，兼容 LangChain 的输出格式，便于后续处理和比较。

## LLMFactory 类
- `get_supported_models`返回模型列表和提供商。
-  `create_llm`根据模型名和提供商自动创建对应的 LLM 实例，识别和参数传递。
- `_create_openai_llm`创建 OpenAI 的 ChatOpenAI 实例，自动读取 API 密钥和 base_url。
- `_create_qwen_llm`创建 QwenChatModel 实例，自动读取 API 密钥。
